### PR TITLE
Add per-project venv creation and split CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
       AWX_REPO_NAME: awx
       EDA_PG_PORT: 15432
       EDA_REDIS_PORT: 16379
-      GATEWAY_REDIS_PORT: 16380
       GALAXY_PG_PORT: 15433
     strategy:
       fail-fast: false
@@ -160,21 +159,9 @@ jobs:
             venv: eda-server-split
             check: eda-server
             python: '3.11'
-          - project: awx_plugins.interfaces
-            venv: awx-plugins-interfaces-split
-            check: awx_plugins.interfaces
-            python: '3.11'
-          - project: awx-plugins
-            venv: awx-plugins-split
-            check: awx-plugins
-            python: '3.11'
           - project: ansible-runner
             venv: ansible-runner-split
             check: ansible-runner
-            python: '3.11'
-          - project: dispatcherd
-            venv: dispatcherd-split
-            check: dispatcherd
             python: '3.11'
           - project: galaxy_ng
             venv: galaxy-ng-split
@@ -215,29 +202,11 @@ jobs:
         repository: ansible/django-ansible-base
         path: ${{ github.workspace }}/repos/django-ansible-base
 
-    - name: Checkout AWX Plugins Interfaces
-      uses: actions/checkout@v4
-      with:
-        repository: ansible/awx_plugins.interfaces
-        path: ${{ github.workspace }}/repos/awx_plugins.interfaces
-
-    - name: Checkout AWX Plugins
-      uses: actions/checkout@v4
-      with:
-        repository: ansible/awx-plugins
-        path: ${{ github.workspace }}/repos/awx-plugins
-
     - name: Checkout Ansible Runner
       uses: actions/checkout@v4
       with:
         repository: ansible/ansible-runner
         path: ${{ github.workspace }}/repos/ansible-runner
-
-    - name: Checkout Dispatcherd
-      uses: actions/checkout@v4
-      with:
-        repository: ansible/dispatcherd
-        path: ${{ github.workspace }}/repos/dispatcherd
 
     - name: Checkout Galaxy NG
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,6 @@ jobs:
             venv: eda-server-split
             check: eda-server
             python: '3.11'
-          - project: ansible-runner
-            venv: ansible-runner-split
-            check: ansible-runner
-            python: '3.11'
           - project: galaxy_ng
             venv: galaxy-ng-split
             check: galaxy_ng
@@ -201,12 +197,6 @@ jobs:
       with:
         repository: ansible/django-ansible-base
         path: ${{ github.workspace }}/repos/django-ansible-base
-
-    - name: Checkout Ansible Runner
-      uses: actions/checkout@v4
-      with:
-        repository: ansible/ansible-runner
-        path: ${{ github.workspace }}/repos/ansible-runner
 
     - name: Checkout Galaxy NG
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  unified:
     runs-on: ubuntu-latest
     env:
       REPO_ROOT: ${{ github.workspace }}/repos
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
-        
+
     steps:
     - name: Checkout editable-venvs
       uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
         sudo systemctl start postgresql
         sudo systemctl start redis-server
 
-    - name: Create test virtual environment
+    - name: Create unified virtual environment
       run: |
         cd ${{ github.workspace }}/editable-venvs
         export CONFIG_DIR=config-public
@@ -114,6 +114,160 @@ jobs:
         cd ${{ github.workspace }}/editable-venvs
         source $HOME/venvs/test-ci/bin/activate
         ./checks/canary.sh eda
+
+    - name: Debug sanitized files on failure
+      if: failure()
+      run: |
+        cd ${{ github.workspace }}/editable-venvs
+        echo "🔍 DEBUG: Contents of sanitized/ folder:"
+        if [ -d "sanitized" ]; then
+          for file in sanitized/*; do
+            if [ -f "$file" ]; then
+              echo "📄 File: $file"
+              echo "----------------------------------------"
+              cat "$file"
+              echo "----------------------------------------"
+              echo
+            fi
+          done
+        else
+          echo "❌ sanitized/ directory not found"
+        fi
+
+  split-projects:
+    runs-on: ubuntu-latest
+    needs: unified
+    env:
+      REPO_ROOT: ${{ github.workspace }}/repos
+      AWX_REPO_NAME: awx
+      EDA_PG_PORT: 15432
+      EDA_REDIS_PORT: 16379
+      GATEWAY_REDIS_PORT: 16380
+      GALAXY_PG_PORT: 15433
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: awx
+            venv: awx-split
+            check: awx
+            python: '3.11'
+          - project: django-ansible-base
+            venv: dab-split
+            check: django-ansible-base
+            python: '3.11'
+          - project: eda-server
+            venv: eda-server-split
+            check: eda-server
+            python: '3.11'
+          - project: awx_plugins.interfaces
+            venv: awx-plugins-interfaces-split
+            check: awx_plugins.interfaces
+            python: '3.11'
+          - project: awx-plugins
+            venv: awx-plugins-split
+            check: awx-plugins
+            python: '3.11'
+          - project: ansible-runner
+            venv: ansible-runner-split
+            check: ansible-runner
+            python: '3.11'
+          - project: dispatcherd
+            venv: dispatcherd-split
+            check: dispatcherd
+            python: '3.11'
+          - project: galaxy_ng
+            venv: galaxy-ng-split
+            check: galaxy_ng
+            python: '3.11'
+
+    steps:
+    - name: Checkout editable-venvs
+      uses: actions/checkout@v4
+      with:
+        path: editable-venvs
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Set up repositories directory
+      run: |
+        mkdir -p $HOME/repos
+        cd $HOME/repos
+
+    - name: Checkout AWX
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/awx
+        path: ${{ github.workspace }}/repos/awx
+
+    - name: Checkout EDA Server
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/eda-server
+        path: ${{ github.workspace }}/repos/eda-server
+
+    - name: Checkout django-ansible-base
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/django-ansible-base
+        path: ${{ github.workspace }}/repos/django-ansible-base
+
+    - name: Checkout AWX Plugins Interfaces
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/awx_plugins.interfaces
+        path: ${{ github.workspace }}/repos/awx_plugins.interfaces
+
+    - name: Checkout AWX Plugins
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/awx-plugins
+        path: ${{ github.workspace }}/repos/awx-plugins
+
+    - name: Checkout Ansible Runner
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/ansible-runner
+        path: ${{ github.workspace }}/repos/ansible-runner
+
+    - name: Checkout Dispatcherd
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/dispatcherd
+        path: ${{ github.workspace }}/repos/dispatcherd
+
+    - name: Checkout Galaxy NG
+      uses: actions/checkout@v4
+      with:
+        repository: ansible/galaxy_ng
+        path: ${{ github.workspace }}/repos/galaxy_ng
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          postgresql postgresql-contrib redis-server docker-compose \
+          libxml2-dev libxmlsec1-dev libxmlsec1-openssl \
+          libldap2-dev libsasl2-dev libssl-dev \
+          python3-dev build-essential pkg-config \
+          libtool-bin
+        sudo systemctl start postgresql
+        sudo systemctl start redis-server
+
+    - name: Create project virtual environment
+      run: |
+        cd ${{ github.workspace }}/editable-venvs
+        export CONFIG_DIR=config-public
+        ./create_project_venv.sh ${{ matrix.venv }} ${{ matrix.project }}
+
+    - name: Run project canary test
+      run: |
+        cd ${{ github.workspace }}/editable-venvs
+        source $HOME/venvs/${{ matrix.venv }}/bin/activate
+        ./checks/canary.sh ${{ matrix.check }}
 
     - name: Debug sanitized files on failure
       if: failure()

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Creates a clean, isolated virtual environment at `~/venvs/<venv-name>` containin
 
 ## Usage
 
+### Unified environment
+
 ```bash
 # Create environment for AWX development
 PYTHON=python3.11 ./create_venv.sh awx
@@ -99,11 +101,26 @@ After completion, activate the environment:
 source ~/venvs/awx/bin/activate
 ```
 
+### Project-specific environments
+
+Use `create_project_venv.sh` to build an isolated virtual environment for a single repository. The script reads project metadata from `config/project_settings.json` (or another `CONFIG_DIR`) and reuses the existing installer while limiting the scope to the requested project.
+
+```bash
+# Create a venv only for awx
+PYTHON=python3.11 ./create_project_venv.sh awx-dev awx
+
+# Create a venv for galaxy_ng using the new split configuration
+CONFIG_DIR=config-public ./create_project_venv.sh galaxy-demo galaxy_ng
+```
+
+Project entries include optional extra requirement files that install after the base environment has been created, which is useful for test-only dependencies.
+
 ## Project Structure
 
 ```
 editable-venvs/
 ├── create_venv.sh                    # Main script
+├── create_project_venv.sh            # Project-scoped environment helper
 ├── config/                           # Configuration files
 │   ├── editable_projects.txt         # Projects to install with dependencies
 │   ├── editable_projects_no_deps.txt # Projects to install with --no-deps
@@ -111,7 +128,8 @@ editable-venvs/
 │   ├── pre_requirements.txt          # Requirements to install directly (no exclusions)
 │   ├── requirement_files.txt         # Additional requirements files to install
 │   ├── exclude_for_files.txt         # Packages to exclude during installation
-│   └── constraints_for_editable.txt  # Version constraints for editable installs
+│   ├── constraints_for_editable.txt  # Version constraints for editable installs
+│   └── project_settings.json         # Metadata for per-project environments
 ├── checks/                           # Verification tools
 ├── sanitized/                        # Generated filtered requirements files
 ├── notes/                            # Documentation and migration notes
@@ -137,6 +155,7 @@ editable-venvs/
 - **`config/requirement_files.txt`**: Additional requirements files to install before projects
 - **`config/exclude_for_files.txt`**: Packages to exclude during requirements installation
 - **`config/constraints_for_editable.txt`**: Version constraints to apply during installation
+- **`config/project_settings.json`**: Describes how each individual project should be installed when using `create_project_venv.sh`, including extras, requirement files, and optional Poetry export flags. Public automation uses `config-public/project_settings.json`, which includes the `galaxy_ng` split environment while keeping it out of the unified environment.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ editable-venvs/
 
 ### Other Configuration Files
 
-- **`config/poetry_projects.txt`**: Projects using Poetry whose dependencies should be exported via `poetry export`
+- **`config/poetry_projects.txt`**: Projects using Poetry whose dependencies should be exported via `poetry export`. Entries may
+  optionally append `:<group1,group2>` to request extra Poetry dependency groups during export.
 - **`config/requirement_files.txt`**: Additional requirements files to install before projects
 - **`config/exclude_for_files.txt`**: Packages to exclude during requirements installation
 - **`config/constraints_for_editable.txt`**: Version constraints to apply during installation
-- **`config/project_settings.json`**: Describes how each individual project should be installed when using `create_project_venv.sh`, including extras, requirement files, and optional Poetry export flags. Public automation uses `config-public/project_settings.json`, which includes the `galaxy_ng` split environment while keeping it out of the unified environment.
+- **`config/project_settings.json`**: Describes how each individual project should be installed when using `create_project_venv.sh`, including extras, requirement files, and optional Poetry export flags. You can set `"poetry": true` to enable exports and `"poetry_groups"` to request additional Poetry groups (for example, `"test"` so pytest is available for `eda-server`). Public automation uses `config-public/project_settings.json`, which includes the `galaxy_ng` split environment while keeping it out of the unified environment.
 
 ## Environment Variables
 
@@ -172,7 +173,8 @@ The tool automatically handles projects that use Poetry for dependency managemen
 2. **Automatic Export**: Uses `poetry export` to generate requirements.txt files
 3. **Seamless Integration**: Poetry-exported dependencies are installed alongside other requirements
 
-Poetry projects are listed in `config/poetry_projects.txt` (one per line) and must contain a `pyproject.toml` file.
+Poetry projects are listed in `config/poetry_projects.txt` (one per line) and must contain a `pyproject.toml` file. Lines may specify
+additional dependency groups using the format `repo:group1,group2`.
 
 ## Verification Tools
 

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -89,6 +89,8 @@ run_galaxy_ng() {
       exit 1
     fi
 
+    compose -p galaxy_ng -f dev/compose/aap.yaml down --remove-orphans --volumes >/dev/null 2>&1 || true
+
     compose_args=(-p galaxy_ng -f dev/compose/aap.yaml)
     override_file=""
 
@@ -105,7 +107,6 @@ run_galaxy_ng() {
       fi
     }
 
-    cleanup
     trap cleanup EXIT
 
     compose "${compose_args[@]}" up --force-recreate -d postgres >/dev/null

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -3,13 +3,12 @@ set -euo pipefail
 
 REPO_ROOT="${REPO_ROOT:-$HOME/repos}"
 AWX_REPO_NAME="${AWX_REPO_NAME:-tower}"  # Default to tower, can override with awx
-CHECK_FILTER="${1:-}"  # Optional arg: awx, dab, eda, gateway
+CHECK_FILTER="${1:-}"  # Optional arg: awx, dab, eda, ansible-runner, galaxy_ng
 
 # Configurable ports for CI/local compatibility
 # These can be overridden via environment variables (e.g., in GitHub Actions)
 EDA_PG_PORT="${EDA_PG_PORT:-5432}"
 EDA_REDIS_PORT="${EDA_REDIS_PORT:-6379}"
-GATEWAY_REDIS_PORT="${GATEWAY_REDIS_PORT:-6379}"
 GALAXY_PG_PORT="${GALAXY_PG_PORT:-5433}"
 
 echo "🐤 Running canary tests..."
@@ -49,26 +48,6 @@ run_eda() {
   )
 }
 
-run_awx_plugins() {
-  echo
-  echo "🔎 awx-plugins"
-  echo "Using repository: $REPO_ROOT/awx-plugins"
-  (
-    cd "$REPO_ROOT/awx-plugins" &&
-    pytest tests/github_app_test.py::test_github_app_invalid_args
-  )
-}
-
-run_awx_plugins_interfaces() {
-  echo
-  echo "🔎 awx_plugins.interfaces"
-  echo "Using repository: $REPO_ROOT/awx_plugins.interfaces"
-  (
-    cd "$REPO_ROOT/awx_plugins.interfaces" &&
-    pytest tests/smoke_test.py::test_smoke
-  )
-}
-
 run_runner() {
   echo
   echo "🔎 ansible-runner"
@@ -76,16 +55,6 @@ run_runner() {
   (
     cd "$REPO_ROOT/ansible-runner" &&
     pytest test/unit/test_utils.py::test_artifact_permissions
-  )
-}
-
-run_dispatcherd() {
-  echo
-  echo "🔎 dispatcherd"
-  echo "Using repository: $REPO_ROOT/dispatcherd"
-  (
-    cd "$REPO_ROOT/dispatcherd" &&
-    pytest tests/test_noop_broker.py::test_noop_broker_publish_message
   )
 }
 
@@ -125,37 +94,13 @@ run_galaxy_ng() {
   )
 }
 
-run_gateway() {
-    echo
-    echo "🔎 aap-gateway"
-    echo "Using repository: $REPO_ROOT/aap-gateway"
-    (
-        cd "$REPO_ROOT/aap-gateway" &&
-        # Use configurable Redis port (defaults to standard port, can be overridden in CI)
-        export REDIS_PORT="$GATEWAY_REDIS_PORT"
-        
-        # Ensure cleanup on exit
-        trap 'docker compose -f tools/generated/docker-compose.yml down --remove-orphans' EXIT
-        
-        docker compose -f tools/generated/docker-compose.yml up -d db redis1 &&
-        DATABASE_NAME=gateway DATABASE_USER=gateway DATABASE_PASSWORD=gateway DATABASE_HOST=localhost DATABASE_PORT=5440 \
-        REDIS_URL=redis://localhost:$GATEWAY_REDIS_PORT REDIS_HOSTS=localhost:$GATEWAY_REDIS_PORT REDIS_MODE=standalone \
-        GATEWAY_SECRET_KEY_FILE=tools/configs/dev_secret_key DJANGO_SETTINGS_MODULE=aap_gateway_api.settings \
-        pytest aap_gateway_api/tests/views/api/test_api_root.py
-    )
-}
-
 case "$CHECK_FILTER" in
   "" )
     run_awx
     run_dab
     run_eda
-    run_awx_plugins
-    run_awx_plugins_interfaces
     run_runner
-    run_dispatcherd
     run_galaxy_ng
-    run_gateway
     ;;
   awx )
     run_awx
@@ -166,27 +111,15 @@ case "$CHECK_FILTER" in
   eda | eda-server )
     run_eda
     ;;
-  awx-plugins )
-    run_awx_plugins
-    ;;
-  awx_plugins.interfaces )
-    run_awx_plugins_interfaces
-    ;;
   ansible-runner )
     run_runner
-    ;;
-  dispatcherd )
-    run_dispatcherd
     ;;
   galaxy_ng )
     run_galaxy_ng
     ;;
-  gateway )
-    run_gateway
-    ;;
   * )
     echo "❌ Unknown check: $CHECK_FILTER"
-    echo "   Expected one of: awx, dab, django-ansible-base, eda, eda-server, awx-plugins, awx_plugins.interfaces, ansible-runner, dispatcherd, galaxy_ng, gateway"
+    echo "   Expected one of: awx, dab, django-ansible-base, eda, eda-server, ansible-runner, galaxy_ng"
     exit 1
     ;;
 esac

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -84,10 +84,31 @@ run_galaxy_ng() {
     export PULP_MEDIA_ROOT="/tmp/pulp/media"
     export PULP_FILE_UPLOAD_TEMP_DIR="/tmp/pulp/artifact-tmp"
 
-    compose_file="dev/compose/aap.yaml"
-    trap 'compose -f "$compose_file" down --remove-orphans' EXIT
-    compose -f "$compose_file" up --force-recreate -d postgres
-    compose -f "$compose_file" exec -T postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done"
+    if ! command -v docker >/dev/null 2>&1; then
+      echo "❌ docker is required to run the galaxy_ng check" >&2
+      exit 1
+    fi
+
+    container_name="galaxy-ng-postgres"
+    image="quay.io/sclorg/postgresql-15-c9s:latest"
+
+    cleanup() {
+      docker rm -f "$container_name" >/dev/null 2>&1 || true
+    }
+
+    cleanup
+    trap cleanup EXIT
+
+    docker run \
+      --detach \
+      --name "$container_name" \
+      --publish "$GALAXY_PG_PORT:5432" \
+      --env POSTGRESQL_USER=galaxy_ng \
+      --env POSTGRESQL_PASSWORD=galaxy_ng \
+      --env POSTGRESQL_DATABASE=galaxy_ng \
+      "$image" >/dev/null
+
+    docker exec -T "$container_name" bash -c 'until pg_isready -U galaxy_ng -h 127.0.0.1 -p 5432; do sleep 1; done'
 
     rm -rf /tmp/pulp
     mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -90,9 +90,19 @@ run_galaxy_ng() {
     fi
 
     compose_args=(-p galaxy_ng -f dev/compose/aap.yaml)
+    override_file=""
+
+    if [[ -n "${GALAXY_PG_PORT:-}" ]]; then
+      override_file="$(mktemp)"
+      printf 'services:\n  postgres:\n    ports:\n      - "%s:5432"\n' "$GALAXY_PG_PORT" >"$override_file"
+      compose_args+=(-f "$override_file")
+    fi
 
     cleanup() {
       compose "${compose_args[@]}" down --remove-orphans --volumes >/dev/null 2>&1 || true
+      if [[ -n "$override_file" && -f "$override_file" ]]; then
+        rm -f "$override_file"
+      fi
     }
 
     cleanup

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -110,6 +110,7 @@ run_galaxy_ng() {
 
     compose "${compose_args[@]}" up --force-recreate -d postgres >/dev/null
     compose "${compose_args[@]}" exec postgres bash -c 'while ! pg_isready -U galaxy_ng; do sleep 1; done'
+    sleep 10
 
     rm -rf /tmp/pulp
     mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -3,13 +3,28 @@ set -euo pipefail
 
 REPO_ROOT="${REPO_ROOT:-$HOME/repos}"
 AWX_REPO_NAME="${AWX_REPO_NAME:-tower}"  # Default to tower, can override with awx
-CHECK_FILTER="${1:-}"  # Optional arg: awx, dab, eda, ansible-runner, galaxy_ng
+CHECK_FILTER="${1:-}"  # Optional arg: awx, dab, eda, galaxy_ng
 
 # Configurable ports for CI/local compatibility
 # These can be overridden via environment variables (e.g., in GitHub Actions)
 EDA_PG_PORT="${EDA_PG_PORT:-5432}"
 EDA_REDIS_PORT="${EDA_REDIS_PORT:-6379}"
 GALAXY_PG_PORT="${GALAXY_PG_PORT:-5433}"
+
+compose() {
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+    return
+  fi
+
+  if command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+    return
+  fi
+
+  echo "❌ docker compose/docker-compose is required but not installed" >&2
+  return 1
+}
 
 echo "🐤 Running canary tests..."
 
@@ -38,23 +53,13 @@ run_eda() {
     export EDA_REDIS_PORT="$EDA_REDIS_PORT"
     
     # Ensure cleanup on exit
-    trap 'docker-compose -p eda -f tools/docker/docker-compose-dev.yaml down --remove-orphans' EXIT
-    
-    docker-compose -p eda -f tools/docker/docker-compose-dev.yaml up --detach postgres redis &&
+    trap 'compose -p eda -f tools/docker/docker-compose-dev.yaml down --remove-orphans' EXIT
+
+    compose -p eda -f tools/docker/docker-compose-dev.yaml up --detach postgres redis &&
     # Update database connection to use the configured ports
     EDA_DB_HOST=localhost EDA_DB_PORT="$EDA_PG_PORT" EDA_MQ_HOST=localhost EDA_MQ_PORT="$EDA_REDIS_PORT" \
-    DJANGO_SETTINGS_MODULE=aap_eda.settings.default EDA_SECRET_KEY=insecure EDA_DB_PASSWORD=secret \
+      DJANGO_SETTINGS_MODULE=aap_eda.settings.default EDA_SECRET_KEY=insecure EDA_DB_PASSWORD=secret \
       pytest tests/integration/api/test_eda_credential.py
-  )
-}
-
-run_runner() {
-  echo
-  echo "🔎 ansible-runner"
-  echo "Using repository: $REPO_ROOT/ansible-runner"
-  (
-    cd "$REPO_ROOT/ansible-runner" &&
-    pytest test/unit/test_utils.py::test_artifact_permissions
   )
 }
 
@@ -80,9 +85,9 @@ run_galaxy_ng() {
     export PULP_FILE_UPLOAD_TEMP_DIR="/tmp/pulp/artifact-tmp"
 
     compose_file="dev/compose/aap.yaml"
-    trap 'docker compose -f "$compose_file" down --remove-orphans' EXIT
-    docker compose -f "$compose_file" up --force-recreate -d postgres
-    docker compose -f "$compose_file" exec postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done"
+    trap 'compose -f "$compose_file" down --remove-orphans' EXIT
+    compose -f "$compose_file" up --force-recreate -d postgres
+    compose -f "$compose_file" exec -T postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done"
 
     rm -rf /tmp/pulp
     mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets
@@ -99,7 +104,6 @@ case "$CHECK_FILTER" in
     run_awx
     run_dab
     run_eda
-    run_runner
     run_galaxy_ng
     ;;
   awx )
@@ -111,15 +115,12 @@ case "$CHECK_FILTER" in
   eda | eda-server )
     run_eda
     ;;
-  ansible-runner )
-    run_runner
-    ;;
   galaxy_ng )
     run_galaxy_ng
     ;;
   * )
     echo "❌ Unknown check: $CHECK_FILTER"
-    echo "   Expected one of: awx, dab, django-ansible-base, eda, eda-server, ansible-runner, galaxy_ng"
+    echo "   Expected one of: awx, dab, django-ansible-base, eda, eda-server, galaxy_ng"
     exit 1
     ;;
 esac

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -89,26 +89,17 @@ run_galaxy_ng() {
       exit 1
     fi
 
-    container_name="galaxy-ng-postgres"
-    image="quay.io/sclorg/postgresql-15-c9s:latest"
+    compose_args=(-p galaxy_ng -f dev/compose/aap.yaml)
 
     cleanup() {
-      docker rm -f "$container_name" >/dev/null 2>&1 || true
+      compose "${compose_args[@]}" down --remove-orphans --volumes >/dev/null 2>&1 || true
     }
 
     cleanup
     trap cleanup EXIT
 
-    docker run \
-      --detach \
-      --name "$container_name" \
-      --publish "$GALAXY_PG_PORT:5432" \
-      --env POSTGRESQL_USER=galaxy_ng \
-      --env POSTGRESQL_PASSWORD=galaxy_ng \
-      --env POSTGRESQL_DATABASE=galaxy_ng \
-      "$image" >/dev/null
-
-    docker exec "$container_name" bash -c 'until pg_isready -U galaxy_ng -h 127.0.0.1 -p 5432; do sleep 1; done'
+    compose "${compose_args[@]}" up --force-recreate -d postgres >/dev/null
+    compose "${compose_args[@]}" exec postgres bash -c 'while ! pg_isready -U galaxy_ng; do sleep 1; done'
 
     rm -rf /tmp/pulp
     mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -10,6 +10,7 @@ CHECK_FILTER="${1:-}"  # Optional arg: awx, dab, eda, gateway
 EDA_PG_PORT="${EDA_PG_PORT:-5432}"
 EDA_REDIS_PORT="${EDA_REDIS_PORT:-6379}"
 GATEWAY_REDIS_PORT="${GATEWAY_REDIS_PORT:-6379}"
+GALAXY_PG_PORT="${GALAXY_PG_PORT:-5433}"
 
 echo "🐤 Running canary tests..."
 
@@ -48,6 +49,82 @@ run_eda() {
   )
 }
 
+run_awx_plugins() {
+  echo
+  echo "🔎 awx-plugins"
+  echo "Using repository: $REPO_ROOT/awx-plugins"
+  (
+    cd "$REPO_ROOT/awx-plugins" &&
+    pytest tests/github_app_test.py::test_github_app_invalid_args
+  )
+}
+
+run_awx_plugins_interfaces() {
+  echo
+  echo "🔎 awx_plugins.interfaces"
+  echo "Using repository: $REPO_ROOT/awx_plugins.interfaces"
+  (
+    cd "$REPO_ROOT/awx_plugins.interfaces" &&
+    pytest tests/smoke_test.py::test_smoke
+  )
+}
+
+run_runner() {
+  echo
+  echo "🔎 ansible-runner"
+  echo "Using repository: $REPO_ROOT/ansible-runner"
+  (
+    cd "$REPO_ROOT/ansible-runner" &&
+    pytest test/unit/test_utils.py::test_artifact_permissions
+  )
+}
+
+run_dispatcherd() {
+  echo
+  echo "🔎 dispatcherd"
+  echo "Using repository: $REPO_ROOT/dispatcherd"
+  (
+    cd "$REPO_ROOT/dispatcherd" &&
+    pytest tests/test_noop_broker.py::test_noop_broker_publish_message
+  )
+}
+
+run_galaxy_ng() {
+  echo
+  echo "🔎 galaxy_ng"
+  echo "Using repository: $REPO_ROOT/galaxy_ng"
+  (
+    set -euo pipefail
+    cd "$REPO_ROOT/galaxy_ng"
+    export DJANGO_SETTINGS_MODULE="pulpcore.app.settings"
+    export PULP_DATABASES__default__ENGINE="django.db.backends.postgresql"
+    export PULP_DATABASES__default__NAME="galaxy_ng"
+    export PULP_DATABASES__default__USER="galaxy_ng"
+    export PULP_DATABASES__default__PASSWORD="galaxy_ng"
+    export PULP_DATABASES__default__HOST="localhost"
+    export PULP_DATABASES__default__PORT="$GALAXY_PG_PORT"
+    export PULP_DB_ENCRYPTION_KEY="/tmp/database_fields.symmetric.key"
+    export PULP_DEPLOY_ROOT="/tmp/pulp"
+    export PULP_STATIC_ROOT="/tmp/pulp"
+    export PULP_WORKING_DIRECTORY="/tmp/pulp/tmp"
+    export PULP_MEDIA_ROOT="/tmp/pulp/media"
+    export PULP_FILE_UPLOAD_TEMP_DIR="/tmp/pulp/artifact-tmp"
+
+    compose_file="dev/compose/aap.yaml"
+    trap 'docker compose -f "$compose_file" down --remove-orphans' EXIT
+    docker compose -f "$compose_file" up --force-recreate -d postgres
+    docker compose -f "$compose_file" exec postgres bash -c "while ! pg_isready -U galaxy_ng; do sleep 1; done"
+
+    rm -rf /tmp/pulp
+    mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets
+    if [[ ! -f /tmp/database_fields.symmetric.key ]]; then
+      openssl rand -base64 32 > /tmp/database_fields.symmetric.key
+    fi
+
+    pytest galaxy_ng/tests/unit/test_models.py::TestSetting::test_get_settings_as_dict
+  )
+}
+
 run_gateway() {
     echo
     echo "🔎 aap-gateway"
@@ -73,23 +150,43 @@ case "$CHECK_FILTER" in
     run_awx
     run_dab
     run_eda
+    run_awx_plugins
+    run_awx_plugins_interfaces
+    run_runner
+    run_dispatcherd
+    run_galaxy_ng
     run_gateway
     ;;
   awx )
     run_awx
     ;;
-  dab )
+  dab | django-ansible-base )
     run_dab
     ;;
-  eda )
+  eda | eda-server )
     run_eda
+    ;;
+  awx-plugins )
+    run_awx_plugins
+    ;;
+  awx_plugins.interfaces )
+    run_awx_plugins_interfaces
+    ;;
+  ansible-runner )
+    run_runner
+    ;;
+  dispatcherd )
+    run_dispatcherd
+    ;;
+  galaxy_ng )
+    run_galaxy_ng
     ;;
   gateway )
     run_gateway
     ;;
   * )
     echo "❌ Unknown check: $CHECK_FILTER"
-    echo "   Expected one of: awx, dab, eda, gateway"
+    echo "   Expected one of: awx, dab, django-ansible-base, eda, eda-server, awx-plugins, awx_plugins.interfaces, ansible-runner, dispatcherd, galaxy_ng, gateway"
     exit 1
     ;;
 esac

--- a/checks/canary.sh
+++ b/checks/canary.sh
@@ -108,7 +108,7 @@ run_galaxy_ng() {
       --env POSTGRESQL_DATABASE=galaxy_ng \
       "$image" >/dev/null
 
-    docker exec -T "$container_name" bash -c 'until pg_isready -U galaxy_ng -h 127.0.0.1 -p 5432; do sleep 1; done'
+    docker exec "$container_name" bash -c 'until pg_isready -U galaxy_ng -h 127.0.0.1 -p 5432; do sleep 1; done'
 
     rm -rf /tmp/pulp
     mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets

--- a/config-public/project_settings.json
+++ b/config-public/project_settings.json
@@ -5,7 +5,8 @@
     "extras": [],
     "requirements": [
       "awx/requirements/requirements.txt",
-      "awx/requirements/requirements_dev.txt"
+      "awx/requirements/requirements_dev.txt",
+      "awx/requirements/requirements_git.txt"
     ]
   },
   "django-ansible-base": {
@@ -31,7 +32,10 @@
     "install_type": "editable",
     "extras": [],
     "requirements": [],
-    "poetry": true
+    "poetry": true,
+    "poetry_groups": [
+      "test"
+    ]
   },
   "awx_plugins.interfaces": {
     "repo": "awx_plugins.interfaces",
@@ -51,15 +55,6 @@
     "requirements": [],
     "post_requirements": [
       "awx-plugins/dependencies/direct/py.in"
-    ]
-  },
-  "ansible-runner": {
-    "repo": "ansible-runner",
-    "install_type": "editable",
-    "extras": [],
-    "requirements": [],
-    "post_requirements": [
-      "ansible-runner/test/requirements.txt"
     ]
   },
   "dispatcherd": {

--- a/config-public/project_settings.json
+++ b/config-public/project_settings.json
@@ -1,0 +1,83 @@
+{
+  "awx": {
+    "repo": "awx",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [
+      "awx/requirements/requirements.txt",
+      "awx/requirements/requirements_dev.txt"
+    ]
+  },
+  "django-ansible-base": {
+    "repo": "django-ansible-base",
+    "install_type": "editable_no_deps",
+    "extras": [
+      "authentication",
+      "rest-filters",
+      "jwt_consumer",
+      "resource-registry",
+      "rbac",
+      "feature-flags",
+      "api-documentation",
+      "oauth2-provider"
+    ],
+    "requirements": [
+      "django-ansible-base/requirements/requirements_dev.txt",
+      "django-ansible-base/requirements/requirements_all.txt"
+    ]
+  },
+  "eda-server": {
+    "repo": "eda-server",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "poetry": true
+  },
+  "awx_plugins.interfaces": {
+    "repo": "awx_plugins.interfaces",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "awx_plugins.interfaces/dependencies/direct/py.in"
+    ]
+  },
+  "awx-plugins": {
+    "repo": "awx-plugins",
+    "install_type": "editable",
+    "extras": [
+      "credentials-github-app"
+    ],
+    "requirements": [],
+    "post_requirements": [
+      "awx-plugins/dependencies/direct/py.in"
+    ]
+  },
+  "ansible-runner": {
+    "repo": "ansible-runner",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "ansible-runner/test/requirements.txt"
+    ]
+  },
+  "dispatcherd": {
+    "repo": "dispatcherd",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "dispatcherd/requirements_dev.txt"
+    ]
+  },
+  "galaxy_ng": {
+    "repo": "galaxy_ng",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "galaxy_ng/unittest_requirements.txt"
+    ]
+  }
+}

--- a/config/project_settings.json
+++ b/config/project_settings.json
@@ -5,7 +5,8 @@
     "extras": [],
     "requirements": [
       "awx/requirements/requirements.txt",
-      "awx/requirements/requirements_dev.txt"
+      "awx/requirements/requirements_dev.txt",
+      "awx/requirements/requirements_git.txt"
     ]
   },
   "django-ansible-base": {
@@ -31,7 +32,10 @@
     "install_type": "editable",
     "extras": [],
     "requirements": [],
-    "poetry": true
+    "poetry": true,
+    "poetry_groups": [
+      "test"
+    ]
   },
   "awx_plugins.interfaces": {
     "repo": "awx_plugins.interfaces",
@@ -51,15 +55,6 @@
     "requirements": [],
     "post_requirements": [
       "awx-plugins/dependencies/direct/py.in"
-    ]
-  },
-  "ansible-runner": {
-    "repo": "ansible-runner",
-    "install_type": "editable",
-    "extras": [],
-    "requirements": [],
-    "post_requirements": [
-      "ansible-runner/test/requirements.txt"
     ]
   },
   "dispatcherd": {

--- a/config/project_settings.json
+++ b/config/project_settings.json
@@ -1,0 +1,83 @@
+{
+  "awx": {
+    "repo": "awx",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [
+      "awx/requirements/requirements.txt",
+      "awx/requirements/requirements_dev.txt"
+    ]
+  },
+  "django-ansible-base": {
+    "repo": "django-ansible-base",
+    "install_type": "editable_no_deps",
+    "extras": [
+      "authentication",
+      "rest-filters",
+      "jwt_consumer",
+      "resource-registry",
+      "rbac",
+      "feature-flags",
+      "api-documentation",
+      "oauth2-provider"
+    ],
+    "requirements": [
+      "django-ansible-base/requirements/requirements_dev.txt",
+      "django-ansible-base/requirements/requirements_all.txt"
+    ]
+  },
+  "eda-server": {
+    "repo": "eda-server",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "poetry": true
+  },
+  "awx_plugins.interfaces": {
+    "repo": "awx_plugins.interfaces",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "awx_plugins.interfaces/dependencies/direct/py.in"
+    ]
+  },
+  "awx-plugins": {
+    "repo": "awx-plugins",
+    "install_type": "editable",
+    "extras": [
+      "credentials-github-app"
+    ],
+    "requirements": [],
+    "post_requirements": [
+      "awx-plugins/dependencies/direct/py.in"
+    ]
+  },
+  "ansible-runner": {
+    "repo": "ansible-runner",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "ansible-runner/test/requirements.txt"
+    ]
+  },
+  "dispatcherd": {
+    "repo": "dispatcherd",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "dispatcherd/requirements_dev.txt"
+    ]
+  },
+  "galaxy_ng": {
+    "repo": "galaxy_ng",
+    "install_type": "editable",
+    "extras": [],
+    "requirements": [],
+    "post_requirements": [
+      "galaxy_ng/unittest_requirements.txt"
+    ]
+  }
+}

--- a/create_project_venv.sh
+++ b/create_project_venv.sh
@@ -53,7 +53,21 @@ install_type = info.get("install_type", "editable")
 repo = info.get("repo", project_key)
 extras = info.get("extras", [])
 requirements = info.get("requirements", [])
-poetry = bool(info.get("poetry", False))
+
+poetry_field = info.get("poetry", False)
+poetry_enabled = bool(poetry_field)
+
+poetry_groups = info.get("poetry_groups", [])
+if isinstance(poetry_groups, str):
+    poetry_groups = [poetry_groups]
+elif poetry_groups is None:
+    poetry_groups = []
+else:
+    poetry_groups = list(poetry_groups)
+
+poetry_groups = [str(group) for group in poetry_groups if str(group).strip()]
+poetry_entry_groups = ",".join(poetry_groups)
+
 post_requirements = info.get("post_requirements", [])
 
 editable_lines = []
@@ -72,11 +86,18 @@ elif install_type == "editable_no_deps":
 else:
     raise SystemExit(f"❌ Unsupported install_type '{install_type}' for project '{project_key}'")
 
+poetry_lines = []
+if poetry_enabled or poetry_entry_groups:
+    poetry_line = repo
+    if poetry_entry_groups:
+        poetry_line = f"{repo}:{poetry_entry_groups}"
+    poetry_lines.append(poetry_line)
+
 files_to_write = {
     "editable_projects.txt": editable_lines,
     "editable_projects_no_deps.txt": no_deps_lines,
     "requirement_files.txt": requirements,
-    "poetry_projects.txt": [repo] if poetry else [],
+    "poetry_projects.txt": poetry_lines,
     "post_requirements.txt": post_requirements,
 }
 

--- a/create_project_venv.sh
+++ b/create_project_venv.sh
@@ -34,7 +34,7 @@ for base_file in constraints_for_editable.txt exclude_for_files.txt pre_requirem
   fi
 done
 
-python <<'PY' "$PROJECT_SETTINGS_FILE" "$PROJECT_KEY" "$TEMP_CONFIG_DIR"
+python - "$PROJECT_SETTINGS_FILE" "$PROJECT_KEY" "$TEMP_CONFIG_DIR" <<'PY'
 import json
 import sys
 from pathlib import Path

--- a/create_project_venv.sh
+++ b/create_project_venv.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 2 ]]; then
+  echo "Usage: $0 <venv-name> <project-key>" >&2
+  exit 1
+fi
+
+VENV_NAME="$1"
+PROJECT_KEY="$2"
+
+REPO_ROOT="${REPO_ROOT:-$HOME/repos}"
+CONFIG_DIR="${CONFIG_DIR:-config}"
+PROJECT_SETTINGS_FILE="$CONFIG_DIR/project_settings.json"
+
+if [[ ! -f "$PROJECT_SETTINGS_FILE" ]]; then
+  echo "❌ Missing project configuration file: $PROJECT_SETTINGS_FILE" >&2
+  exit 1
+fi
+
+TEMP_CONFIG_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_CONFIG_DIR"' EXIT
+
+# Ensure the temp config contains copies of baseline files expected by create_venv.sh
+for base_file in constraints_for_editable.txt exclude_for_files.txt pre_requirements.txt; do
+  src="$CONFIG_DIR/$base_file"
+  dest="$TEMP_CONFIG_DIR/$base_file"
+  if [[ -f "$src" ]]; then
+    cp "$src" "$dest"
+  else
+    # create empty file to satisfy create_venv.sh checks when optional
+    : > "$dest"
+  fi
+done
+
+python <<'PY' "$PROJECT_SETTINGS_FILE" "$PROJECT_KEY" "$TEMP_CONFIG_DIR"
+import json
+import sys
+from pathlib import Path
+
+config_path, project_key, dest_dir = sys.argv[1:]
+dest = Path(dest_dir)
+
+data = json.load(open(config_path, "r", encoding="utf-8"))
+if project_key not in data:
+    available = ", ".join(sorted(data))
+    raise SystemExit(f"❌ Unknown project '{project_key}'. Available projects: {available}")
+
+info = data[project_key]
+
+install_type = info.get("install_type", "editable")
+repo = info.get("repo", project_key)
+extras = info.get("extras", [])
+requirements = info.get("requirements", [])
+poetry = bool(info.get("poetry", False))
+post_requirements = info.get("post_requirements", [])
+
+editable_lines = []
+no_deps_lines = []
+if extras:
+    extras_str = ",".join(extras)
+else:
+    extras_str = ""
+
+line = repo if not extras_str else f"{repo}:{extras_str}"
+
+if install_type == "editable":
+    editable_lines.append(line)
+elif install_type == "editable_no_deps":
+    no_deps_lines.append(line)
+else:
+    raise SystemExit(f"❌ Unsupported install_type '{install_type}' for project '{project_key}'")
+
+files_to_write = {
+    "editable_projects.txt": editable_lines,
+    "editable_projects_no_deps.txt": no_deps_lines,
+    "requirement_files.txt": requirements,
+    "poetry_projects.txt": [repo] if poetry else [],
+    "post_requirements.txt": post_requirements,
+}
+
+for filename, entries in files_to_write.items():
+    target = dest / filename
+    content = "\n".join(entries)
+    target.write_text(content + ("\n" if content else ""), encoding="utf-8")
+PY
+
+CONFIG_DIR="$TEMP_CONFIG_DIR" "$(dirname "$0")/create_venv.sh" "$VENV_NAME"
+
+POST_REQ_FILE="$TEMP_CONFIG_DIR/post_requirements.txt"
+if [[ -s "$POST_REQ_FILE" ]]; then
+  echo
+  echo "Phase 5: Installing additional project-specific requirement files"
+  source "$HOME/venvs/$VENV_NAME/bin/activate"
+  PIP_QUIET="${PIP_QUIET:-1}"
+  PIP_INSTALL_CMD=(pip install)
+  if [[ "$PIP_QUIET" == "1" ]]; then
+    PIP_INSTALL_CMD+=(--quiet --disable-pip-version-check)
+  fi
+  while IFS= read -r requirement_path; do
+    [[ -z "$requirement_path" ]] && continue
+    full_path="$REPO_ROOT/$requirement_path"
+    if [[ ! -f "$full_path" ]]; then
+      echo "Skipping missing requirement file: $full_path"
+      continue
+    fi
+    echo "  Installing extra requirements: $full_path"
+    "${PIP_INSTALL_CMD[@]}" -r "$full_path"
+  done < "$POST_REQ_FILE"
+fi
+
+echo
+VENV_DIR="$HOME/venvs/$VENV_NAME"
+echo "Project-specific venv setup complete: $VENV_DIR"
+echo "Run this to activate it:"
+echo "source $VENV_DIR/bin/activate"

--- a/create_venv.sh
+++ b/create_venv.sh
@@ -125,8 +125,15 @@ if [[ -f "$POETRY_PROJECTS_FILE" ]]; then
   echo
   echo "Phase 2.5: Exporting poetry projects to requirements files"
 
-  while IFS= read -r poetry_project; do
-    [[ -z "$poetry_project" || "$poetry_project" =~ ^# ]] && continue
+  while IFS= read -r poetry_line; do
+    [[ -z "$poetry_line" || "$poetry_line" =~ ^# ]] && continue
+
+    poetry_project="${poetry_line%%:*}"
+    poetry_groups_raw="${poetry_line#*:}"
+    if [[ "$poetry_groups_raw" == "$poetry_line" ]]; then
+      poetry_groups_raw=""
+    fi
+
     poetry_project_path="$REPO_ROOT/$poetry_project"
     if [[ ! -d "$poetry_project_path" ]]; then
       echo "Skipping missing poetry project: $poetry_project_path"
@@ -139,8 +146,19 @@ if [[ -f "$POETRY_PROJECTS_FILE" ]]; then
 
     sanitized_poetry_req="$SANITIZED_DIR/$(basename "$poetry_project").txt"
     echo "  Exporting poetry project $poetry_project to: $sanitized_poetry_req"
-    echo "    Running: poetry export --without-hashes -f requirements.txt -C $poetry_project_path"
-    "$BUILD_VENV_DIR/bin/poetry" export --without-hashes -f requirements.txt -o "$(pwd)/$sanitized_poetry_req" -C "$poetry_project_path"
+    cmd=("$BUILD_VENV_DIR/bin/poetry" export --without-hashes -f requirements.txt -o "$(pwd)/$sanitized_poetry_req" -C "$poetry_project_path")
+
+    if [[ -n "$poetry_groups_raw" ]]; then
+      # Allow multiple groups, separated by commas in the config entry
+      poetry_groups="$(echo "$poetry_groups_raw" | tr -d '[:space:]')"
+      if [[ -n "$poetry_groups" ]]; then
+        cmd+=(--with "$poetry_groups")
+        echo "    Including Poetry groups: $poetry_groups"
+      fi
+    fi
+
+    echo "    Running: ${cmd[*]}"
+    "${cmd[@]}"
     echo "    Export completed successfully"
   done < "$POETRY_PROJECTS_FILE"
 fi

--- a/notes/checks-playbook.md
+++ b/notes/checks-playbook.md
@@ -73,14 +73,20 @@ AWX_LOGGING_MODE=stdout pytest \
      -r requirements/requirements_dev.txt \
      -r requirements/requirements_all.txt
    ```
-3. Install the package with the extras expected by the smoke test while avoiding a second dependency resolution pass:
+3. Install the package with the extras expected by the smoke test:
    ```bash
-   pip install -e .[authentication,rest-filters,jwt_consumer,resource-registry,rbac,feature-flags,api-documentation,oauth2-provider] --no-deps
+   pip install -e .[authentication,rest-filters,jwt_consumer,resource-registry,rbac,feature-flags,api-documentation,oauth2-provider]
    ```
+
+### Start PostgreSQL via docker compose
+The repository ships a compose definition and convenience target that provisions PostgreSQL for development:
+```bash
+make postgres
+```
+This target wraps the repository's Docker Compose configuration and returns once the database container is accepting connections.
 
 ### Run the smoke test
 ```bash
-make postgres
 pytest test_app/tests/rbac/models/test_uniqueness.py
 ```
 
@@ -179,26 +185,6 @@ PULP_MEDIA_ROOT=/tmp/pulp/media \
 PULP_FILE_UPLOAD_TEMP_DIR=/tmp/pulp/artifact-tmp \
 pytest galaxy_ng/tests/unit/test_models.py::TestSetting::test_get_settings_as_dict
 ```
-
-## aap-gateway (reference)
-
-While this private repository is not exercised by automated checks here, the shared tooling reveals how to bootstrap its environment:
-
-1. Create and activate a virtual environment:
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   python -m pip install --upgrade pip
-   ```
-2. Install the pinned requirements used across the fleet:
-   ```bash
-   pip install -r requirements/requirements.txt
-   ```
-3. Install the gateway in editable mode without re-resolving dependencies:
-   ```bash
-   pip install -e . --no-deps
-   ```
-4. Execute the repository's targeted validation command (for example `pytest` or a tox environment) as documented in the project README.
 
 ## Cross-project template
 

--- a/notes/checks-playbook.md
+++ b/notes/checks-playbook.md
@@ -2,6 +2,32 @@
 
 This guide summarizes the minimum manual steps required to reproduce the canary checks run by this repository for each supported project. All commands assume repositories live under `$REPO_ROOT` (default: `$HOME/repos`) and virtual environments are created in `$HOME/venvs`.
 
+## Common prerequisites
+
+1. Install the system packages that the checks expect. The GitHub runners use the following sets:
+   - **Fedora/RHEL:**
+     ```bash
+     sudo dnf install -y \
+       postgresql postgresql-server postgresql-contrib redis \
+       docker-compose-plugin docker \
+       libxml2-devel libxmlsec1-devel libxmlsec1-openssl \
+       openldap-devel cyrus-sasl-devel openssl-devel \
+       python3-devel gcc gcc-c++ make pkgconfig libtool
+     ```
+   - **Debian/Ubuntu:**
+     ```bash
+     sudo apt-get update
+     sudo apt-get install -y \
+       postgresql postgresql-contrib redis-server docker-compose \
+       libxml2-dev libxmlsec1-dev libxmlsec1-openssl \
+       libldap2-dev libsasl2-dev libssl-dev \
+       python3-dev build-essential pkg-config \
+       libtool-bin
+     ```
+   Ensure the Docker daemon is running (e.g., `sudo systemctl start docker`) so compose commands can launch services.
+2. Create the repositories directory and clone the projects under `$REPO_ROOT` if they are not already present.
+3. When using Poetry-backed projects, keep the shared configuration files in `config/` or `config-public/` available so the helper scripts can resolve groups and post-install requirements.
+
 ## AWX
 
 ### Prepare a project virtual environment
@@ -165,9 +191,9 @@ While this private repository is not exercised by automated checks here, the sha
 
 Use this template to capture new project smoke tests in a consistent format.
 
-1. **Clone and path setup**
-   - Ensure the repository lives under `$REPO_ROOT/<project>`.
-   - Export any project-specific environment variables required for tooling (e.g., `AWX_REPO_NAME`, custom ports).
+1. **System dependencies**
+   - Install platform packages and command-line tools required by the project (database clients, Docker, build headers). See [Common prerequisites](#common-prerequisites) for baseline packages.
+   - Export any project-specific environment variables required before provisioning services.
 2. **Virtual environment creation**
    - For unified installs: `CONFIG_DIR=<config> ./create_venv.sh <venv-name>`.
    - For split installs: `CONFIG_DIR=<config> ./create_project_venv.sh <venv-name> <project-key>`.

--- a/notes/checks-playbook.md
+++ b/notes/checks-playbook.md
@@ -1,0 +1,198 @@
+# Project Check Playbook
+
+This guide summarizes the minimum manual steps required to reproduce the canary checks run by this repository for each supported project. All commands assume repositories live under `$REPO_ROOT` (default: `$HOME/repos`) and virtual environments are created in `$HOME/venvs`.
+
+## AWX
+
+### Prepare a project virtual environment
+1. Ensure the repository is cloned at `$REPO_ROOT/awx`.
+2. Create a split virtual environment with the public configuration:
+   ```bash
+   CONFIG_DIR=config-public ./create_project_venv.sh awx-canary awx
+   ```
+3. Activate the environment:
+   ```bash
+   source ~/venvs/awx-canary/bin/activate
+   ```
+
+### Run the smoke test
+```bash
+cd "$REPO_ROOT/awx"
+AWX_LOGGING_MODE=stdout pytest \
+  awx/main/tests/functional/test_instances.py \
+  --create-db \
+  --disable-warnings \
+  -W ignore::DeprecationWarning
+```
+
+## django-ansible-base
+
+### Prepare a project virtual environment
+1. Confirm the repository is available at `$REPO_ROOT/django-ansible-base`.
+2. Create the environment with Poetry extras defined in `config/project_settings.json`:
+   ```bash
+   CONFIG_DIR=config-public ./create_project_venv.sh dab-canary django-ansible-base
+   ```
+3. Activate the environment:
+   ```bash
+   source ~/venvs/dab-canary/bin/activate
+   ```
+
+### Run the smoke test
+```bash
+cd "$REPO_ROOT/django-ansible-base"
+make postgres
+pytest test_app/tests/rbac/models/test_uniqueness.py
+```
+
+Stop the temporary PostgreSQL container with:
+```bash
+cd "$REPO_ROOT/django-ansible-base"
+make postgres-down
+```
+
+## eda-server
+
+### Prepare a project virtual environment
+1. Verify the repository resides at `$REPO_ROOT/eda-server`.
+2. Build the environment (the configuration exports Poetry's `test` group so pytest is available):
+   ```bash
+   CONFIG_DIR=config-public ./create_project_venv.sh eda-canary eda-server
+   ```
+3. Activate the environment:
+   ```bash
+   source ~/venvs/eda-canary/bin/activate
+   ```
+
+### Start supporting services
+```bash
+cd "$REPO_ROOT/eda-server"
+EDA_PG_PORT=5432 EDA_REDIS_PORT=6379 \
+  docker compose -p eda -f tools/docker/docker-compose-dev.yaml up --detach postgres redis
+```
+Wait for both services to report healthy status (the compose file configures health checks).
+
+### Run the smoke test
+```bash
+cd "$REPO_ROOT/eda-server"
+EDA_DB_HOST=localhost EDA_DB_PORT=5432 \
+EDA_MQ_HOST=localhost EDA_MQ_PORT=6379 \
+DJANGO_SETTINGS_MODULE=aap_eda.settings.default \
+EDA_SECRET_KEY=insecure \
+EDA_DB_PASSWORD=secret \
+pytest tests/integration/api/test_eda_credential.py
+```
+
+### Tear down services
+```bash
+cd "$REPO_ROOT/eda-server"
+docker compose -p eda -f tools/docker/docker-compose-dev.yaml down --remove-orphans
+```
+
+## galaxy_ng
+
+### Prepare a project virtual environment
+1. Confirm `$REPO_ROOT/galaxy_ng` exists.
+2. Build the split environment (post requirements install `unittest_requirements.txt`):
+   ```bash
+   CONFIG_DIR=config-public ./create_project_venv.sh galaxy-canary galaxy_ng
+   ```
+3. Activate the environment:
+   ```bash
+   source ~/venvs/galaxy-canary/bin/activate
+   ```
+
+### Start PostgreSQL via docker compose
+```bash
+cd "$REPO_ROOT/galaxy_ng"
+docker compose -p galaxy_ng -f dev/compose/aap.yaml up --force-recreate -d postgres
+```
+Wait for readiness:
+```bash
+docker compose -p galaxy_ng -f dev/compose/aap.yaml exec postgres \
+  bash -c 'while ! pg_isready -U galaxy_ng; do sleep 1; done'
+```
+
+### Prepare runtime directories
+```bash
+rm -rf /tmp/pulp
+mkdir -p /tmp/pulp/tmp /tmp/pulp/artifact-tmp /tmp/pulp/media /tmp/pulp/assets
+if [[ ! -f /tmp/database_fields.symmetric.key ]]; then
+  openssl rand -base64 32 > /tmp/database_fields.symmetric.key
+fi
+```
+
+### Run the smoke test
+```bash
+cd "$REPO_ROOT/galaxy_ng"
+DJANGO_SETTINGS_MODULE=pulpcore.app.settings \
+PULP_DATABASES__default__ENGINE=django.db.backends.postgresql \
+PULP_DATABASES__default__NAME=galaxy_ng \
+PULP_DATABASES__default__USER=galaxy_ng \
+PULP_DATABASES__default__PASSWORD=galaxy_ng \
+PULP_DATABASES__default__HOST=localhost \
+PULP_DATABASES__default__PORT=5433 \
+PULP_DB_ENCRYPTION_KEY=/tmp/database_fields.symmetric.key \
+PULP_DEPLOY_ROOT=/tmp/pulp \
+PULP_STATIC_ROOT=/tmp/pulp \
+PULP_WORKING_DIRECTORY=/tmp/pulp/tmp \
+PULP_MEDIA_ROOT=/tmp/pulp/media \
+PULP_FILE_UPLOAD_TEMP_DIR=/tmp/pulp/artifact-tmp \
+pytest galaxy_ng/tests/unit/test_models.py::TestSetting::test_get_settings_as_dict
+```
+
+### Tear down services
+```bash
+docker compose -p galaxy_ng -f dev/compose/aap.yaml down --remove-orphans --volumes
+```
+
+## aap-gateway (reference)
+
+While this private repository is not exercised by automated checks here, the shared tooling reveals how to bootstrap its environment:
+
+1. Include the repository in the unified environment by running:
+   ```bash
+   CONFIG_DIR=config ./create_venv.sh gateway-dev
+   ```
+   This configuration installs `aap-gateway` in editable mode without automatic dependency resolution and consumes `aap-gateway/requirements/requirements.txt` to provide its pinned dependencies.
+2. Activate the environment:
+   ```bash
+   source ~/venvs/gateway-dev/bin/activate
+   ```
+3. Follow the repository's internal README to run its validation suite (commonly a targeted `pytest` or tox environment). The unified environment already aligns protobuf-related pins with the rest of the stack, as documented in `config/pre_requirements.txt`.
+
+## Cross-project template
+
+Use this template to capture new project smoke tests in a consistent format.
+
+1. **Clone and path setup**
+   - Ensure the repository lives under `$REPO_ROOT/<project>`.
+   - Export any project-specific environment variables required for tooling (e.g., `AWX_REPO_NAME`, custom ports).
+2. **Virtual environment creation**
+   - For unified installs: `CONFIG_DIR=<config> ./create_venv.sh <venv-name>`.
+   - For split installs: `CONFIG_DIR=<config> ./create_project_venv.sh <venv-name> <project-key>`.
+   - Activate with `source ~/venvs/<venv-name>/bin/activate`.
+3. **Optional dependency extras**
+   - Install post-requirement files or editable siblings with `pip install -e ../<dependency>` if the repository detects optional neighbors.
+4. **Service orchestration**
+   - Start required infrastructure (databases, cache, message brokers) via Docker:
+     ```bash
+     docker compose -p <project> -f <path/to/compose>.yaml up --detach <services>
+     ```
+   - Alternatively, use helper targets such as `make postgres` when provided.
+   - Wait for readiness by polling health checks, e.g.:
+     ```bash
+     docker compose -p <project> -f <compose>.yaml exec <service> \
+       bash -c 'while ! pg_isready -U <user> -h <host> -p <port>; do sleep 1; done'
+     ```
+5. **Filesystem bootstrap**
+   - Create or reset working directories expected by the app (for example `/tmp/pulp` trees or asset caches).
+   - Generate encryption keys or secrets if they are not checked into the repository.
+6. **Execute the smoke test**
+   - Run the minimal high-signal command (pytest module, Django check, etc.).
+   - Capture artifacts such as coverage or JUnit XML when useful for CI.
+7. **Cleanup**
+   - Stop auxiliary services with `docker compose ... down --remove-orphans` (add `--volumes` if the data should be discarded).
+   - Deactivate the virtual environment if desired.
+
+Populate each placeholder with concrete values from the target repository to produce a reproducible check recipe.

--- a/notes/checks-playbook.md
+++ b/notes/checks-playbook.md
@@ -1,6 +1,6 @@
 # Project Check Playbook
 
-This guide summarizes the minimum manual steps required to reproduce the canary checks run by this repository for each supported project. All commands assume repositories live under `$REPO_ROOT` (default: `$HOME/repos`) and virtual environments are created in `$HOME/venvs`.
+This guide summarizes the minimum manual steps required to reproduce the canary checks run by this repository for each supported project. Unless otherwise noted, run the commands from the root of the corresponding project repository.
 
 ## Common prerequisites
 
@@ -25,25 +25,32 @@ This guide summarizes the minimum manual steps required to reproduce the canary 
        libtool-bin
      ```
    Ensure the Docker daemon is running (e.g., `sudo systemctl start docker`) so compose commands can launch services.
-2. Create the repositories directory and clone the projects under `$REPO_ROOT` if they are not already present.
-3. When using Poetry-backed projects, keep the shared configuration files in `config/` or `config-public/` available so the helper scripts can resolve groups and post-install requirements.
+2. Clone the target repository locally if it is not already present.
+3. Create a fresh Python virtual environment (for example `python3 -m venv .venv`) before installing project-specific dependencies.
 
 ## AWX
 
 ### Prepare a project virtual environment
-1. Ensure the repository is cloned at `$REPO_ROOT/awx`.
-2. Create a split virtual environment with the public configuration:
+1. Create and activate a virtual environment:
    ```bash
-   CONFIG_DIR=config-public ./create_project_venv.sh awx-canary awx
+   python3 -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip
    ```
-3. Activate the environment:
+2. Install the AWX dependency sets:
    ```bash
-   source ~/venvs/awx-canary/bin/activate
+   pip install \
+     -r requirements/requirements.txt \
+     -r requirements/requirements_dev.txt \
+     -r requirements/requirements_git.txt
+   ```
+3. Install AWX in editable mode so `pytest` can import the package:
+   ```bash
+   pip install -e .
    ```
 
 ### Run the smoke test
 ```bash
-cd "$REPO_ROOT/awx"
 AWX_LOGGING_MODE=stdout pytest \
   awx/main/tests/functional/test_instances.py \
   --create-db \
@@ -54,45 +61,50 @@ AWX_LOGGING_MODE=stdout pytest \
 ## django-ansible-base
 
 ### Prepare a project virtual environment
-1. Confirm the repository is available at `$REPO_ROOT/django-ansible-base`.
-2. Create the environment with Poetry extras defined in `config/project_settings.json`:
+1. Create and activate a virtual environment:
    ```bash
-   CONFIG_DIR=config-public ./create_project_venv.sh dab-canary django-ansible-base
+   python3 -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip
    ```
-3. Activate the environment:
+2. Install the development requirements that mirror the CI environment:
    ```bash
-   source ~/venvs/dab-canary/bin/activate
+   pip install \
+     -r requirements/requirements_dev.txt \
+     -r requirements/requirements_all.txt
+   ```
+3. Install the package with the extras expected by the smoke test while avoiding a second dependency resolution pass:
+   ```bash
+   pip install -e .[authentication,rest-filters,jwt_consumer,resource-registry,rbac,feature-flags,api-documentation,oauth2-provider] --no-deps
    ```
 
 ### Run the smoke test
 ```bash
-cd "$REPO_ROOT/django-ansible-base"
 make postgres
 pytest test_app/tests/rbac/models/test_uniqueness.py
-```
-
-Stop the temporary PostgreSQL container with:
-```bash
-cd "$REPO_ROOT/django-ansible-base"
-make postgres-down
 ```
 
 ## eda-server
 
 ### Prepare a project virtual environment
-1. Verify the repository resides at `$REPO_ROOT/eda-server`.
-2. Build the environment (the configuration exports Poetry's `test` group so pytest is available):
+1. Create and activate a virtual environment:
    ```bash
-   CONFIG_DIR=config-public ./create_project_venv.sh eda-canary eda-server
+   python3 -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip poetry
    ```
-3. Activate the environment:
+2. Export the Poetry-managed dependencies that power the integration test and install them into the active environment:
    ```bash
-   source ~/venvs/eda-canary/bin/activate
+   poetry export --without-hashes --with test -f requirements.txt -o /tmp/eda-test-requirements.txt
+   pip install -r /tmp/eda-test-requirements.txt
+   ```
+3. Install the repository itself in editable mode:
+   ```bash
+   pip install -e .
    ```
 
 ### Start supporting services
 ```bash
-cd "$REPO_ROOT/eda-server"
 EDA_PG_PORT=5432 EDA_REDIS_PORT=6379 \
   docker compose -p eda -f tools/docker/docker-compose-dev.yaml up --detach postgres redis
 ```
@@ -100,7 +112,6 @@ Wait for both services to report healthy status (the compose file configures hea
 
 ### Run the smoke test
 ```bash
-cd "$REPO_ROOT/eda-server"
 EDA_DB_HOST=localhost EDA_DB_PORT=5432 \
 EDA_MQ_HOST=localhost EDA_MQ_PORT=6379 \
 DJANGO_SETTINGS_MODULE=aap_eda.settings.default \
@@ -109,28 +120,31 @@ EDA_DB_PASSWORD=secret \
 pytest tests/integration/api/test_eda_credential.py
 ```
 
-### Tear down services
-```bash
-cd "$REPO_ROOT/eda-server"
-docker compose -p eda -f tools/docker/docker-compose-dev.yaml down --remove-orphans
-```
-
 ## galaxy_ng
 
 ### Prepare a project virtual environment
-1. Confirm `$REPO_ROOT/galaxy_ng` exists.
-2. Build the split environment (post requirements install `unittest_requirements.txt`):
+1. Create and activate a virtual environment:
    ```bash
-   CONFIG_DIR=config-public ./create_project_venv.sh galaxy-canary galaxy_ng
+   python3 -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip
    ```
-3. Activate the environment:
+2. Install the unit-test dependency lockfile and the package under test:
    ```bash
-   source ~/venvs/galaxy-canary/bin/activate
+   pip install -r unittest_requirements.txt
+   pip install -e .
+   ```
+3. (Optional) If sibling repositories such as `django-ansible-base`, `pulpcore`, `pulp_ansible`, `galaxy-importer`, `dynaconf`, `django`, or `django-rest-framework` are checked out alongside `galaxy_ng`, install them in editable mode to mirror CI's behavior:
+   ```bash
+   for project in ../django-ansible-base ../pulpcore ../pulp_ansible ../galaxy-importer ../dynaconf ../django ../django-rest-framework; do
+     if [[ -d "$project" ]]; then
+       pip install -e "$project"
+     fi
+   done
    ```
 
 ### Start PostgreSQL via docker compose
 ```bash
-cd "$REPO_ROOT/galaxy_ng"
 docker compose -p galaxy_ng -f dev/compose/aap.yaml up --force-recreate -d postgres
 ```
 Wait for readiness:
@@ -150,7 +164,6 @@ fi
 
 ### Run the smoke test
 ```bash
-cd "$REPO_ROOT/galaxy_ng"
 DJANGO_SETTINGS_MODULE=pulpcore.app.settings \
 PULP_DATABASES__default__ENGINE=django.db.backends.postgresql \
 PULP_DATABASES__default__NAME=galaxy_ng \
@@ -167,25 +180,25 @@ PULP_FILE_UPLOAD_TEMP_DIR=/tmp/pulp/artifact-tmp \
 pytest galaxy_ng/tests/unit/test_models.py::TestSetting::test_get_settings_as_dict
 ```
 
-### Tear down services
-```bash
-docker compose -p galaxy_ng -f dev/compose/aap.yaml down --remove-orphans --volumes
-```
-
 ## aap-gateway (reference)
 
 While this private repository is not exercised by automated checks here, the shared tooling reveals how to bootstrap its environment:
 
-1. Include the repository in the unified environment by running:
+1. Create and activate a virtual environment:
    ```bash
-   CONFIG_DIR=config ./create_venv.sh gateway-dev
+   python3 -m venv .venv
+   source .venv/bin/activate
+   python -m pip install --upgrade pip
    ```
-   This configuration installs `aap-gateway` in editable mode without automatic dependency resolution and consumes `aap-gateway/requirements/requirements.txt` to provide its pinned dependencies.
-2. Activate the environment:
+2. Install the pinned requirements used across the fleet:
    ```bash
-   source ~/venvs/gateway-dev/bin/activate
+   pip install -r requirements/requirements.txt
    ```
-3. Follow the repository's internal README to run its validation suite (commonly a targeted `pytest` or tox environment). The unified environment already aligns protobuf-related pins with the rest of the stack, as documented in `config/pre_requirements.txt`.
+3. Install the gateway in editable mode without re-resolving dependencies:
+   ```bash
+   pip install -e . --no-deps
+   ```
+4. Execute the repository's targeted validation command (for example `pytest` or a tox environment) as documented in the project README.
 
 ## Cross-project template
 
@@ -195,11 +208,11 @@ Use this template to capture new project smoke tests in a consistent format.
    - Install platform packages and command-line tools required by the project (database clients, Docker, build headers). See [Common prerequisites](#common-prerequisites) for baseline packages.
    - Export any project-specific environment variables required before provisioning services.
 2. **Virtual environment creation**
-   - For unified installs: `CONFIG_DIR=<config> ./create_venv.sh <venv-name>`.
-   - For split installs: `CONFIG_DIR=<config> ./create_project_venv.sh <venv-name> <project-key>`.
-   - Activate with `source ~/venvs/<venv-name>/bin/activate`.
-3. **Optional dependency extras**
-   - Install post-requirement files or editable siblings with `pip install -e ../<dependency>` if the repository detects optional neighbors.
+   - Create an isolated environment with `python3 -m venv .venv` (or an equivalent tool) and activate it.
+   - Upgrade pip and install the repository's requirement files or Poetry exports that correspond to the desired test target.
+3. **Project installation**
+   - Install the repository itself in editable mode, optionally including extras, for example: `pip install -e .[extra-a,extra-b]`.
+   - Add neighboring editable checkouts when the project autodetects them (for instance sibling Django or pulpcore packages).
 4. **Service orchestration**
    - Start required infrastructure (databases, cache, message brokers) via Docker:
      ```bash
@@ -216,9 +229,5 @@ Use this template to capture new project smoke tests in a consistent format.
    - Generate encryption keys or secrets if they are not checked into the repository.
 6. **Execute the smoke test**
    - Run the minimal high-signal command (pytest module, Django check, etc.).
-   - Capture artifacts such as coverage or JUnit XML when useful for CI.
-7. **Cleanup**
-   - Stop auxiliary services with `docker compose ... down --remove-orphans` (add `--volumes` if the data should be discarded).
-   - Deactivate the virtual environment if desired.
 
 Populate each placeholder with concrete values from the target repository to produce a reproducible check recipe.


### PR DESCRIPTION
## Summary
- add a create_project_venv.sh helper that filters configuration to build a venv for a single project
- describe per-project environments in project_settings.json and surface galaxy_ng only in the split workflow
- split CI into unified and per-project jobs with targeted smoke tests for each repository

## Testing
- bash -n create_project_venv.sh

------
https://chatgpt.com/codex/tasks/task_e_68f0fc7262e4832290f83fe13a474996